### PR TITLE
Add X-Forwarded-Host header

### DIFF
--- a/reverseproxy/fasthttp.go
+++ b/reverseproxy/fasthttp.go
@@ -214,6 +214,7 @@ func (rp *FastReverseProxy) handler(ctx *fasthttp.RequestCtx) {
 	isIP := net.ParseIP(hostOnly) != nil
 	if !isIP {
 		req.Header.SetBytesV("X-Host", uri.Host())
+		req.Header.SetBytesV("X-Forwarded-Host", uri.Host())
 		uri.SetHost(hostOnly)
 	}
 	client := rp.getClient(dstHost, dstScheme == "https")

--- a/reverseproxy/native.go
+++ b/reverseproxy/native.go
@@ -260,6 +260,7 @@ func (rp *NativeReverseProxy) roundTripWithData(req *http.Request, reqData *Requ
 	isIP := net.ParseIP(host) != nil
 	if !isIP {
 		req.Header.Set("X-Host", req.Host)
+		req.Header.Set("X-Forwarded-Host", req.Host)
 		req.Host = host
 	}
 	t0 := time.Now().UTC()

--- a/reverseproxy/reverseproxy_test.go
+++ b/reverseproxy/reverseproxy_test.go
@@ -109,6 +109,7 @@ func (s *S) TestRoundTrip(c *check.C) {
 	c.Assert(receivedReq.Host, check.Equals, "myhost.com")
 	c.Assert(receivedReq.Header.Get("X-My-Header"), check.Equals, "myvalue")
 	c.Assert(receivedReq.Header.Get("X-Host"), check.Equals, "")
+	c.Assert(receivedReq.Header.Get("X-Forwarded-Host"), check.Equals, "")
 	c.Assert(receivedReq.Header.Get("X-RID"), check.Not(check.Equals), "")
 	c.Assert(router.resultHost, check.Equals, "myhost.com")
 	c.Assert(router.resultReqData, check.DeepEquals, &RequestData{
@@ -172,6 +173,7 @@ func (s *S) TestRoundTripWithExistingRequestID(c *check.C) {
 	c.Assert(receivedReq.Host, check.Equals, "myhost.com")
 	c.Assert(receivedReq.Header.Get("X-My-Header"), check.Equals, "myvalue")
 	c.Assert(receivedReq.Header.Get("X-Host"), check.Equals, "")
+	c.Assert(receivedReq.Header.Get("X-Forwarded-Host"), check.Equals, "")
 	c.Assert(receivedReq.Header.Get("X-RID"), check.Equals, "abc")
 }
 
@@ -207,6 +209,7 @@ func (s *S) TestRoundTripHostDestination(c *check.C) {
 	c.Assert(receivedReq.Host, check.Equals, "localhost")
 	c.Assert(receivedReq.Header.Get("X-My-Header"), check.Equals, "myvalue")
 	c.Assert(receivedReq.Header.Get("X-Host"), check.Equals, "myhost.com")
+	c.Assert(receivedReq.Header.Get("X-Forwarded-Host"), check.Equals, "myhost.com")
 	c.Assert(router.resultHost, check.Equals, "myhost.com")
 	c.Assert(router.resultReqData, check.DeepEquals, &RequestData{
 		Backend:    router.dst,


### PR DESCRIPTION
Add a X-Forwarded-Host header when the node url is not an IP.
Following the example of: http://httpd.apache.org/docs/2.2/mod/mod_proxy.html#x-headers