### PR TITLE
updating docs and adding engine tls-sni

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ replacing Hipache's executable for PlanB.
 The following flags are available for configuring PlanB on start-up:
 
 - ``--listen/-l``: the address to which PlanB will bind. Default value is
-  ``0.0.0.0:8989``, if you want to disable http access use `disable`.
+  ``0.0.0.0:8989``, if you want to disable http access use `disabled`.
 - ``--tls-listen``: the address to which PlanB will bind with tls support.
 - ``--load-certificates-from``: Path where certificate will found. If value
   equals 'redis' certificate will be loaded from redis service. Default value
@@ -28,10 +28,14 @@ The following flags are available for configuring PlanB on start-up:
   addresses. Default value is ``localhost``.
 - ``--read-redis-port``: Redis port of the server which contains application
   addresses. Default value is ``6379``.
+- ``--read-redis-password``: Redis password of the server which contains application
+  addresses. If not defined, no authentication will be performed.
 - ``--write-redis-host``: Redis host of the server which PlanB will use for
   publishing dead backends. Default value is ``localhost``.
 - ``--write-redis-port``: Redis port of the server which which PlanB will use
   for publishing dead backends. Default value is ``6379``.
+- ``--write-redis-password``: Redis password of the server which which PlanB will use
+  for publishing dead backends. If not defined, no authentication will be performed.
 - ``--access-log``: File path where access log will be written. If value equals
   ``syslog`` log will be sent to local syslog. If value equals ``stdout`` log will
   be sent to stdout. Default value is ``./access.log``.

--- a/main.go
+++ b/main.go
@@ -72,6 +72,8 @@ func runServer(c *cli.Context) {
 		rp = &reverseproxy.NativeReverseProxy{}
 	case "fasthttp":
 		rp = &reverseproxy.FastReverseProxy{}
+	case "sni":
+		rp = &reverseproxy.SNIReverseProxy{}
 	default:
 		log.Fatal(errors.New("invalid engine"))
 	}
@@ -126,6 +128,7 @@ func runServer(c *cli.Context) {
 		ReverseProxy: rp,
 		Listen:       c.String("listen"),
 		TLSListen:    c.String("tls-listen"),
+		SNIListen:    c.String("sni-listen"),
 		CertLoader:   getCertificateLoader(c, readOpts),
 	}
 
@@ -202,6 +205,10 @@ func main() {
 		cli.StringFlag{
 			Name:  "tls-listen",
 			Usage: "Address to listen with tls",
+		},
+		cli.StringFlag{
+			Name:  "sni-listen",
+			Usage: "Address to listen with tls-sni",
 		},
 		cli.StringFlag{
 			Name:  "metrics-address",

--- a/reverseproxy/sni.go
+++ b/reverseproxy/sni.go
@@ -9,7 +9,7 @@ import (
 	"net"
 	"net/url"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/nu7hatch/gouuid"
 	"github.com/tsuru/planb/log"
 )
 
@@ -29,12 +29,12 @@ func (rp *SNIReverseProxy) Stop() {
 func (rp *SNIReverseProxy) Listen(listener net.Listener) {
 	for {
 		connection, err := listener.Accept()
-		ConnID := uuid.NewV4().String()
+		ConnID, _ := uuid.NewV4()
 		if err != nil {
-			log.ErrorLogger.Print("ERROR in ACCEPT - ", listener.Addr(), " - ", ConnID, " - ", err.Error())
+			log.ErrorLogger.Print("ERROR in ACCEPT - ", listener.Addr(), " - ", ConnID.String(), " - ", err.Error())
 			return
 		}
-		go rp.handleSNIConnection(connection, ConnID)
+		go rp.handleSNIConnection(connection, ConnID.String())
 	}
 }
 

--- a/reverseproxy/sni.go
+++ b/reverseproxy/sni.go
@@ -1,0 +1,176 @@
+// Copyright 2017 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package reverseproxy
+
+import (
+	"io"
+	"net"
+	"net/url"
+
+	uuid "github.com/satori/go.uuid"
+	"github.com/tsuru/planb/log"
+)
+
+type SNIReverseProxy struct {
+	ReverseProxyConfig
+}
+
+func (rp *SNIReverseProxy) Initialize(rpConfig ReverseProxyConfig) error {
+	rp.ReverseProxyConfig = rpConfig
+	return nil
+}
+
+func (rp *SNIReverseProxy) Stop() {
+	// no special treatment for fast reverse proxy
+}
+
+func (rp *SNIReverseProxy) Listen(listener net.Listener) {
+	for {
+		connection, err := listener.Accept()
+		ConnID := uuid.NewV4().String()
+		if err != nil {
+			log.ErrorLogger.Print("ERROR in ACCEPT - ", listener.Addr(), " - ", ConnID, " - ", err.Error())
+			return
+		}
+		go rp.handleSNIConnection(connection, ConnID)
+	}
+}
+
+func (rp *SNIReverseProxy) handleSNIConnection(downstream net.Conn, ConnID string) {
+	firstByte := make([]byte, 1)
+	_, err := downstream.Read(firstByte)
+	if err != nil {
+		log.ErrorLogger.Print("ERROR - Couldn't read first byte - ", ConnID)
+		return
+	}
+	if firstByte[0] != 0x16 {
+		log.ErrorLogger.Print("ERROR - Not TLS - ", ConnID)
+	}
+
+	versionBytes := make([]byte, 2)
+	_, err = downstream.Read(versionBytes)
+	if err != nil {
+		log.ErrorLogger.Print("ERROR - Couldn't read version bytes - ", ConnID)
+		return
+	}
+	if versionBytes[0] < 3 || (versionBytes[0] == 3 && versionBytes[1] < 1) {
+		log.ErrorLogger.Print("ERROR -  SSL < 3.1 so it's still not TLS - ", ConnID)
+		return
+	}
+
+	restLengthBytes := make([]byte, 2)
+	_, err = downstream.Read(restLengthBytes)
+	if err != nil {
+		log.ErrorLogger.Print("ERROR - Couldn't read restLength bytes - ", ConnID)
+		return
+	}
+	restLength := (int(restLengthBytes[0]) << 8) + int(restLengthBytes[1])
+
+	rest := make([]byte, restLength)
+	_, err = downstream.Read(rest)
+	if err != nil {
+		log.ErrorLogger.Print("ERROR - Couldn't read rest of bytes - ", ConnID)
+		return
+	}
+
+	current := 0
+
+	handshakeType := rest[0]
+	current++
+	if handshakeType != 0x1 {
+		log.ErrorLogger.Print("ERROR - Not a ClientHello - ", ConnID)
+		return
+	}
+
+	// Skip over another length
+	current += 3
+	// Skip over protocolversion
+	current += 2
+	// Skip over random number
+	current += 4 + 28
+	// Skip over session ID
+	sessionIDLength := int(rest[current])
+	current++
+	current += sessionIDLength
+
+	cipherSuiteLength := (int(rest[current]) << 8) + int(rest[current+1])
+	current += 2
+	current += cipherSuiteLength
+
+	compressionMethodLength := int(rest[current])
+	current++
+	current += compressionMethodLength
+
+	if current > restLength {
+		log.ErrorLogger.Print("ERROR - no extensions - ", ConnID)
+		return
+	}
+
+	// Skip over extensionsLength
+	// extensionsLength := (int(rest[current]) << 8) + int(rest[current + 1])
+	current += 2
+
+	hostname := ""
+	for current < restLength && hostname == "" {
+		extensionType := (int(rest[current]) << 8) + int(rest[current+1])
+		current += 2
+
+		extensionDataLength := (int(rest[current]) << 8) + int(rest[current+1])
+		current += 2
+
+		if extensionType == 0 {
+
+			// Skip over number of names as we're assuming there's just one
+			current += 2
+
+			nameType := rest[current]
+			current++
+			if nameType != 0 {
+				log.ErrorLogger.Print("ERROR - Not a hostname - ", ConnID)
+				return
+			}
+			nameLen := (int(rest[current]) << 8) + int(rest[current+1])
+			current += 2
+			hostname = string(rest[current : current+nameLen])
+		}
+
+		current += extensionDataLength
+	}
+	if hostname == "" {
+		log.ErrorLogger.Print("ERROR - No hostname - ", ConnID)
+		return
+	}
+
+	reqData, err := rp.Router.ChooseBackend(hostname)
+	if err != nil {
+		log.ErrorLogger.Print("ERROR - ChooseBackend - ", ConnID, " - ", err)
+		return
+	}
+	url, err := url.Parse(reqData.Backend)
+	if err != nil {
+		log.ErrorLogger.Print("ERROR - url.Parse - ", ConnID, " - ", err)
+		return
+	}
+	backendAddress := url.Host
+	upstream, err := net.Dial("tcp", backendAddress)
+	if err != nil {
+		log.ErrorLogger.Print("ERROR - ConnectBackend - ", ConnID, " - ", err)
+		return
+	}
+
+	upstream.Write(firstByte)
+	upstream.Write(versionBytes)
+	upstream.Write(restLengthBytes)
+	upstream.Write(rest)
+
+	errc := make(chan error, 2)
+	cp := func(dst io.Writer, src io.Reader) {
+		_, err := io.Copy(dst, src)
+		errc <- err
+	}
+	go cp(upstream, downstream)
+	go cp(downstream, upstream)
+	<-errc
+}

--- a/reverseproxy/sni_test.go
+++ b/reverseproxy/sni_test.go
@@ -1,0 +1,113 @@
+// // Copyright 2016 tsuru authors. All rights reserved.
+// // Use of this source code is governed by a BSD-style
+// // license that can be found in the LICENSE file.
+
+package reverseproxy
+
+import (
+	"bytes"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+
+	"gopkg.in/check.v1"
+)
+
+type SNI struct {
+	factory   func() ReverseProxy
+	logBuffer *bytes.Buffer
+}
+
+var (
+	sniFactory = func() ReverseProxy { return &SNIReverseProxy{} }
+	_          = check.Suite(&SNI{factory: sniFactory})
+)
+
+// TestRoundTripSNI test SNI reverseproxy using example.com domain
+func (s *SNI) TestRoundTripSNI(c *check.C) {
+	var receivedReq *http.Request
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		receivedReq = req
+		rw.Header().Set("X-Some-Rsp-Header", "rspvalue")
+		rw.WriteHeader(200)
+		rw.Write([]byte("my result"))
+	}))
+	defer ts.Close()
+	router := &recoderRouter{dst: ts.URL}
+	rp := &SNIReverseProxy{}
+	err := rp.Initialize(ReverseProxyConfig{Router: router, RequestIDHeader: "X-RID"})
+	c.Assert(err, check.IsNil)
+	addr, listener := getFreeListener()
+	go rp.Listen(listener)
+	defer rp.Stop()
+	defer listener.Close()
+	req, err := http.NewRequest("GET", fmt.Sprintf("https://%s/", addr), nil)
+	c.Assert(err, check.IsNil)
+	req.Host = "example.com"
+	req.Header.Set("X-My-Header", "myvalue")
+	cert, err := x509.ParseCertificate(ts.TLS.Certificates[0].Certificate[0])
+	c.Assert(err, check.IsNil)
+	certpool := x509.NewCertPool()
+	certpool.AddCert(cert)
+	cli := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs:    certpool,
+				ServerName: req.Host,
+			},
+		},
+	}
+	rsp, err := cli.Do(req)
+	c.Assert(err, check.IsNil)
+	defer rsp.Body.Close()
+	c.Assert(rsp.StatusCode, check.Equals, 200)
+	c.Assert(rsp.Header.Get("X-Some-Rsp-Header"), check.Equals, "rspvalue")
+	data, err := ioutil.ReadAll(rsp.Body)
+	c.Assert(err, check.IsNil)
+	c.Assert(string(data), check.Equals, "my result")
+	c.Assert(receivedReq.Host, check.Equals, "example.com")
+	c.Assert(receivedReq.Header.Get("X-My-Header"), check.Equals, "myvalue")
+	c.Assert(receivedReq.Header.Get("X-Host"), check.Equals, "")
+	c.Assert(receivedReq.Header.Get("X-Forwarded-Host"), check.Equals, "")
+	c.Assert(router.resultHost, check.Equals, "example.com")
+}
+
+// TestRoundTripSNIWithoutHostname test SNI reverseproxy using example.com domain without SNI
+func (s *SNI) TestRoundTripSNIWithoutHostname(c *check.C) {
+	var receivedReq *http.Request
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		receivedReq = req
+		rw.Header().Set("X-Some-Rsp-Header", "rspvalue")
+		rw.WriteHeader(200)
+		rw.Write([]byte("my result"))
+	}))
+	defer ts.Close()
+	router := &recoderRouter{dst: ts.URL}
+	rp := &SNIReverseProxy{}
+	err := rp.Initialize(ReverseProxyConfig{Router: router, RequestIDHeader: "X-RID"})
+	c.Assert(err, check.IsNil)
+	addr, listener := getFreeListener()
+	go rp.Listen(listener)
+	defer rp.Stop()
+	defer listener.Close()
+	req, err := http.NewRequest("GET", fmt.Sprintf("https://%s/", addr), nil)
+	c.Assert(err, check.IsNil)
+	req.Host = "example.com"
+	req.Header.Set("X-My-Header", "myvalue")
+	cert, err := x509.ParseCertificate(ts.TLS.Certificates[0].Certificate[0])
+	c.Assert(err, check.IsNil)
+	certpool := x509.NewCertPool()
+	certpool.AddCert(cert)
+	cli := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs: certpool,
+			},
+		},
+	}
+	_, err = cli.Do(req)
+	c.Assert(err, check.NotNil)
+}


### PR DESCRIPTION
Adding SNI (Server Name Indication) engine, enabling the use of planb in applications with end-to-end encryption, mutual TLS authentication and others uses for TLS protocol with SNI.