### PR TITLE
WIP: Add support to haproxy's proxy-protocol

### DIFF
--- a/main.go
+++ b/main.go
@@ -126,6 +126,7 @@ func runServer(c *cli.Context) {
 		ReadHeaderTimeout: c.Duration("client-read-header-timeout"),
 		WriteTimeout:      c.Duration("client-write-timeout"),
 		IdleTimeout:       c.Duration("client-idle-timeout"),
+		ProxyProtocol:     c.Bool("proxy-protocol"),
 	})
 	if err != nil {
 		log.Fatal(err)
@@ -330,6 +331,10 @@ The value 'none' can be used to disable access logs.`,
 			Name:  "engine",
 			Value: "native",
 			Usage: "Reverse proxy engine, options are 'native', 'sni' and 'fasthttp'. Using 'sni' and 'fasthttp' is highly experimental and not recommended for production environments.",
+		},
+		cli.BoolFlag{
+			Name:  "proxy-protocol",
+			Usage: "Enable parsing HAProxy's PROXY protocol v2 header in tcp connections.",
 		},
 		cli.BoolFlag{
 			Name:  "backend-cache",

--- a/reverseproxy/proxyprotocol.go
+++ b/reverseproxy/proxyprotocol.go
@@ -1,0 +1,79 @@
+// Copyright 2017 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package reverseproxy
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"net"
+)
+
+type proxyHdrV2 struct {
+	Sig    [12]byte /* hex 0D 0A 0D 0A 00 0D 0A 51 55 49 54 0A */
+	VerCmd byte     /* protocol version and command */
+	Fam    byte     /* protocol family and address */
+	Len    uint16   /* number of following bytes part of the header */
+}
+
+type proxyHdrV2Ipv4 struct { /* for TCP/UDP over IPv4, len = 12 */
+	SrcAddr [4]byte
+	DstAddr [4]byte
+	SrcPort uint16
+	DstPort uint16
+}
+
+type proxyHdrV2Ipv6 struct { /* for TCP/UDP over IPv6, len = 36 */
+	SrcAddr [16]byte
+	DstAddr [16]byte
+	SrcPort uint16
+	DstPort uint16
+}
+
+type proxyHdrV2Sock struct { /* for AF_UNIX sockets, len = 216 */
+	SrcAddr [108]byte
+	DstAddr [108]byte
+}
+
+var proxyHdrSig = []byte("\x0D\x0A\x0D\x0A\x00\x0D\x0A\x51\x55\x49\x54\x0A")
+
+func readProxyProtoV2Header(conn net.Conn) (string, error) {
+	var proxyHdr proxyHdrV2
+	err := binary.Read(conn, binary.BigEndian, &proxyHdr)
+	if err != nil {
+		return "", err
+	}
+	if !bytes.Equal(proxyHdr.Sig[:], proxyHdrSig) {
+		return "", errors.New("invalid proxy protocol header")
+	}
+	switch proxyHdr.Len {
+	case 12:
+		var data proxyHdrV2Ipv4
+		err := binary.Read(conn, binary.BigEndian, &data)
+		if err != nil {
+			return "", err
+		}
+		ip := net.IP(data.SrcAddr[:])
+		return fmt.Sprintf("%s:%d", ip.String(), data.SrcPort), nil
+	case 36:
+		var data proxyHdrV2Ipv6
+		err := binary.Read(conn, binary.BigEndian, &data)
+		if err != nil {
+			return "", err
+		}
+		ip := net.IP(data.SrcAddr[:])
+		return fmt.Sprintf("%s:%d", ip.String(), data.SrcPort), nil
+	case 216:
+		var data proxyHdrV2Sock
+		err := binary.Read(conn, binary.BigEndian, &data)
+		if err != nil {
+			return "", err
+		}
+		return string(data.SrcAddr[:]), nil
+	default:
+		return "", errors.New("invalid proxy protocol header")
+	}
+}

--- a/reverseproxy/reverseproxy.go
+++ b/reverseproxy/reverseproxy.go
@@ -45,6 +45,7 @@ type ReverseProxyConfig struct {
 	WriteTimeout      time.Duration
 	IdleTimeout       time.Duration
 	RequestIDHeader   string
+	ProxyProtocol     bool
 }
 
 type RequestData struct {


### PR DESCRIPTION
This is a work in progress.

The PR adds support to HAProxy to reverse proxy engines. Only proxy-protocol v2 will be supported as it's both easier and faster to parse.

### Done:

* Native implementation

### Missing:

* Fasthttp implementation
* Tests
* Benchmarks

### Caveats:

There are some major possible performance implications in the native reverseproxy implementation. Reading the proxy protocol's header happens when we receive a `StateNew` ConnState() call and it blocks until we've finished reading the header, as we must prevent `http.Server` from reading from this connection until we're done. The problem is that `http.Server` calls the `setState` [before a new goroutine is spawned](https://github.com/golang/go/blob/7d33667218ab010022a73b41ea9780474128a35f/src/net/http/server.go#L2746) for the new connection, this means we're blocking the `Accept` loop thus delaying accepting new connections. I don't see a better way for now besides checking with the Go team for the possibility of including a new connection state triggered from inside the new goroutine.

Fixes #33