### PR TITLE
reverseproxy: adds ReadTimeout to test servers

### DIFF
--- a/reverseproxy/reverseproxy_test.go
+++ b/reverseproxy/reverseproxy_test.go
@@ -726,7 +726,7 @@ func (s *S) TestRoundTripStress(c *check.C) {
 	defer ts.Close()
 	router := &noopRouter{dst: ts.URL}
 	rp := s.factory()
-	err := rp.Initialize(ReverseProxyConfig{Router: router})
+	err := rp.Initialize(ReverseProxyConfig{Router: router, ReadTimeout: time.Second})
 	c.Assert(err, check.IsNil)
 	addr, listener := getFreeListener()
 	go rp.Listen(listener, nil)
@@ -763,7 +763,7 @@ func (s *S) TestRoundTripStress(c *check.C) {
 func (s *S) TestRoundTripStressWithTimeoutBackend(c *check.C) {
 	router := &noopRouter{dst: "http://127.0.0.1:23771"}
 	rp := s.factory()
-	err := rp.Initialize(ReverseProxyConfig{Router: router})
+	err := rp.Initialize(ReverseProxyConfig{Router: router, ReadTimeout: time.Second})
 	c.Assert(err, check.IsNil)
 	addr, listener := getFreeListener()
 	go rp.Listen(listener, nil)
@@ -1041,7 +1041,7 @@ func baseBenchmarkServeHTTP(rp ReverseProxy, b *testing.B) {
 		rw.WriteHeader(http.StatusOK)
 	}))
 	defer srv.Close()
-	err := rp.Initialize(ReverseProxyConfig{Router: &noopRouter{dst: srv.URL}})
+	err := rp.Initialize(ReverseProxyConfig{Router: &noopRouter{dst: srv.URL}, ReadTimeout: time.Second})
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -1071,7 +1071,7 @@ func baseBenchmarkServeHTTP(rp ReverseProxy, b *testing.B) {
 
 func baseBenchmarkServeHTTPInvalidFrontends(rp ReverseProxy, b *testing.B) {
 	addr, listener := getFreeListener()
-	err := rp.Initialize(ReverseProxyConfig{Router: &noopRouter{}})
+	err := rp.Initialize(ReverseProxyConfig{Router: &noopRouter{}, ReadTimeout: time.Second})
 	if err != nil {
 		b.Fatal(err)
 	}


### PR DESCRIPTION
This PR adds ReadTimeout to the servers used for testing. The absence of this
timeout causes the call to server.Shutdown to sometimes hit a context timeout (since a connection may be on `new` state waiting to read from the wire), which takes
60 seconds.

Before:
```
$ go test -check.v -check.f TestRoundTripStressWithTimeoutBackend
PASS: reverseproxy_test.go:763: S.TestRoundTripStressWithTimeoutBackend    60.014s
PASS: reverseproxy_test.go:763: S.TestRoundTripStressWithTimeoutBackend    0.013s
OK: 2 passed
PASS
ok      github.com/tsuru/planb/reverseproxy    60.044s
```
After:
```
$ go test -check.v -check.f TestRoundTripStressWithTimeout
PASS: reverseproxy_test.go:763: S.TestRoundTripStressWithTimeoutBackend	1.013s
PASS: reverseproxy_test.go:763: S.TestRoundTripStressWithTimeoutBackend	0.013s
OK: 2 passed
PASS
ok  	github.com/tsuru/planb/reverseproxy	1.055s
```